### PR TITLE
golang 1.10 -> 1.11

### DIFF
--- a/Dockerfile.golang
+++ b/Dockerfile.golang
@@ -1,4 +1,4 @@
-FROM golang:1.10-stretch
+FROM golang:1.11-stretch
 
 # Install unzip and Python build tools to be able to install the AWS CLI tools.
 RUN apt-get update -y && \
@@ -26,6 +26,7 @@ RUN npm install -g serverless@1.30.0
 ENV TZ=Europe/London 
 ENV NODE_ENV=dev
 ENV AWS_DEFAULT_REGION=eu-west-2
+ENV GO111MODULE=on
 
 # Install Go "deployer" Well deployment tool
 RUN go get github.com/welldigital/deployer

--- a/Dockerfile.golang
+++ b/Dockerfile.golang
@@ -26,7 +26,6 @@ RUN npm install -g serverless@1.30.0
 ENV TZ=Europe/London 
 ENV NODE_ENV=dev
 ENV AWS_DEFAULT_REGION=eu-west-2
-ENV GO111MODULE=on
 
 # Install Go "deployer" Well deployment tool
 RUN go get github.com/welldigital/deployer


### PR DESCRIPTION
added ENV GO111MODULE=on
In Go 1.11 the Go module behaviour is disabled by default for packages within $GOPATH (this also includes the default $GOPATH introduced in Go1.8). Thus, without additional configuration, Go1.11 inside Travis CI will behave like Go 1.10.

After discussion with Adrian there was a decision made to use Go Modules for Pharmacy project which is a part of `1.11` version